### PR TITLE
test fixups and default behavior

### DIFF
--- a/rosbag2/include/rosbag2/typesupport_helpers.hpp
+++ b/rosbag2/include/rosbag2/typesupport_helpers.hpp
@@ -16,6 +16,7 @@
 #define ROSBAG2__TYPESUPPORT_HELPERS_HPP_
 
 #include <string>
+#include <tuple>
 #include <utility>
 
 #include "rosidl_generator_cpp/message_type_support_decl.hpp"
@@ -29,7 +30,8 @@ const rosidl_message_type_support_t *
 get_typesupport(const std::string & type, const std::string & typesupport_identifier);
 
 ROSBAG2_PUBLIC
-const std::tuple<std::string, std::string, std::string> extract_type_and_package(const std::string & full_type);
+const std::tuple<std::string, std::string, std::string>
+extract_type_and_package(const std::string & full_type);
 
 }  // namespace rosbag2
 

--- a/rosbag2/src/rosbag2/typesupport_helpers.cpp
+++ b/rosbag2/src/rosbag2/typesupport_helpers.cpp
@@ -17,6 +17,7 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <tuple>
 #include <utility>
 
 #include "ament_index_cpp/get_resources.hpp"
@@ -61,7 +62,8 @@ std::string get_typesupport_library_path(
   return library_path;
 }
 
-const std::tuple<std::string, std::string, std::string> extract_type_and_package(const std::string & full_type)
+const std::tuple<std::string, std::string, std::string>
+extract_type_and_package(const std::string & full_type)
 {
   char type_separator = '/';
   auto sep_position_back = full_type.find_last_of(type_separator);
@@ -75,7 +77,11 @@ const std::tuple<std::string, std::string, std::string> extract_type_and_package
   }
 
   std::string package_name = full_type.substr(0, sep_position_front);
-  std::string middle_module = full_type.substr(sep_position_front + 1, sep_position_back - sep_position_front - 1);
+  std::string middle_module = "";
+  if (sep_position_back - sep_position_front > 0) {
+    middle_module =
+      full_type.substr(sep_position_front + 1, sep_position_back - sep_position_front - 1);
+  }
   std::string type_name = full_type.substr(sep_position_back + 1);
 
   return std::make_tuple(package_name, middle_module, type_name);
@@ -98,7 +104,7 @@ get_typesupport(const std::string & type, const std::string & typesupport_identi
     auto typesupport_library = std::make_shared<Poco::SharedLibrary>(library_path);
 
     auto symbol_name = typesupport_identifier + "__get_message_type_support_handle__" +
-      package_name + "__" + middle_module + "__" + type_name;
+      package_name + "__" + (middle_module.empty() ? "msg" : middle_module) + "__" + type_name;
 
     if (!typesupport_library->hasSymbol(symbol_name)) {
       throw std::runtime_error(poco_dynamic_loading_error + " Symbol not found.");

--- a/rosbag2/test/rosbag2/test_typesupport_helpers.cpp
+++ b/rosbag2/test/rosbag2/test_typesupport_helpers.cpp
@@ -50,7 +50,8 @@ TEST(TypesupportHelpersTest, separates_into_package_and_name_for_multiple_slashe
   std::string package;
   std::string middle_module;
   std::string name;
-  std::tie(package, middle_module, name) = rosbag2::extract_type_and_package("package/middle_module/name");
+  std::tie(package, middle_module, name) =
+    rosbag2::extract_type_and_package("package/middle_module/name");
 
   EXPECT_THAT(package, StrEq("package"));
   EXPECT_THAT(middle_module, StrEq("middle_module"));
@@ -62,9 +63,17 @@ TEST(TypesupportHelpersTest, throws_exception_if_library_cannot_be_found) {
     rosbag2::get_typesupport("invalid/message", "rosidl_typesupport_cpp"), std::runtime_error);
 }
 
-TEST(TypesupportHelpersTest, returns_c_type_info_for_valid_library) {
+TEST(TypesupportHelpersTest, returns_c_type_info_for_valid_legacy_library) {
   auto string_typesupport =
     rosbag2::get_typesupport("test_msgs/BasicTypes", "rosidl_typesupport_cpp");
+
+  EXPECT_THAT(std::string(string_typesupport->typesupport_identifier),
+    ContainsRegex("rosidl_typesupport"));
+}
+
+TEST(TypesupportHelpersTest, returns_c_type_info_for_valid_library) {
+  auto string_typesupport =
+    rosbag2::get_typesupport("test_msgs/msg/BasicTypes", "rosidl_typesupport_cpp");
 
   EXPECT_THAT(std::string(string_typesupport->typesupport_identifier),
     ContainsRegex("rosidl_typesupport"));


### PR DESCRIPTION
a few small fixups for uncrustify and cpplint, but especially introducing some fallback behavior. The tests are currently failing in case there is no `middle_module` present.

This PR makes CI pass on my OSX machine locally and correctly subscribes to messages published by your `idl_pub`:

```
 ➭ ros2 bag info rosbag2_2019_06_10-13_22_07

Files:             rosbag2_2019_06_10-13_22_07.db3
Bag size:          48.4 KiB
Storage id:        sqlite3
Duration:          15.496s
Start:             Jun 10 2019 13:22:07.418 (1560198127.418)
End                Jun 10 2019 13:22:22.915 (1560198142.915)
Messages:          32
Topic information: Topic: /chatter | Type: idl_msgs/idl/StringMsg | Count: 32 | Serialization Format: cdr
```

Signed-off-by: Karsten Knese <karsten@openrobotics.org>